### PR TITLE
Fix on build command and new features

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "api": "DEBUG=pw:api cucumber-js",
     "build": "rimraf build && npm run format && npm run lint && tsc && npm run cucumber-check",
-    "check": "cucumber-js features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format summary --format progress --format progress-bar  --publish-quiet",
+    "cucumber-check": "cucumber-js features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format summary --format progress --format progress-bar  --publish-quiet",
     "debug": "PWDEBUG=1 DEBUG=pw:api cucumber-js",
     "video": "PWVIDEO=1 cucumber-js",
     "eslint-fix": "eslint ./ --ext .js,.ts,.tsx --fix",

--- a/src/support/common-hooks.ts
+++ b/src/support/common-hooks.ts
@@ -24,6 +24,10 @@ setDefaultTimeout(process.env.PWDEBUG ? -1 : 60 * 1000);
 const browserOptions: LaunchOptions = {
   slowMo: 0,
   args: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream'],
+  firefoxUserPrefs: {
+    'media.navigator.streams.fake': true,
+    'media.navigator.permission.disabled': true,
+  },
 };
 
 BeforeAll(async function () {

--- a/src/support/common-hooks.ts
+++ b/src/support/common-hooks.ts
@@ -43,10 +43,6 @@ BeforeAll(async function () {
   }
 });
 
-AfterAll(async function () {
-  await global.browser.close();
-});
-
 Before({ tags: '@ignore' }, async function () {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return 'skipped' as any;
@@ -77,4 +73,8 @@ After(async function (this: ICustomWorld, { result }: ITestCaseHookParameter) {
   }
   await this.page?.close();
   await this.context?.close();
+});
+
+AfterAll(async function () {
+  await global.browser.close();
 });


### PR DESCRIPTION
The `npm run build` command was broken.

I was careless and I was trying to run it on Node v10.19.0. Got an error message until I realize that I didn't check the engines section in `package.json`, so if you find it useful, I introduced the `.npmrc` file that forces an error if the node version installed is bellow the one declared in the engines section in `package.json` when running `npm i`.

Another thing that I saw is some Chromium args to fake video and audio, so I put some for Firefox too. Until now there is no such a thing for WebKit on Playwright. 

Last but not least I thought if the after hooks were all together would be more concise.
