### PR TITLE
Update Readme.md -> to open the html report in Lubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ In [cucumber.js](cucumber.js) file, modify the options.
 
 - run the command `npm run report`.
 
+### At least in Lubuntu 20.04 to open the html report
+
+- Modify the `package.json` in `"report": "xdg-open reports/report.html"`
+
 ## To view allure report
 - run the command `npm run allure`.
 


### PR DESCRIPTION
Open the  html report in Lubuntu 20.04 is fixed modifying the package.json in line 17
` "report": "xdg-open reports/report.html";`

I write it here in case someone have the same problem.

Greetings