### PR TITLE
update `cucumber.js` -> `cucumber.mjs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The last reporter/formatter found on the cucumber-js command-line wins:
 --format summary --format @cucumber/pretty-formatter --format cucumber-console-formatter
 ```
 
-In [cucumber.js](cucumber.js) file, modify the options.
+In [cucumber.mjs](cucumber.mjs) file, modify the options.
 
 ## To ignore a scenario
 


### PR DESCRIPTION
post f8cd51eb94068b8b0d67b6e29a7c9138be8edf1a - `cucumber.js` was changed to `cucumber.mjs` so we should update this link accordingly