### PR TITLE
Fix trace file creation failing on Windows

### DIFF
--- a/src/support/common-hooks.ts
+++ b/src/support/common-hooks.ts
@@ -77,11 +77,13 @@ After(async function (this: ICustomWorld, { result }: ITestCaseHookParameter) {
 
     if (result.status !== Status.PASSED) {
       const image = await this.page?.screenshot();
+
+      // Replace : with _ because colons aren't allowed in Windows paths
+      const timePart = this.startTime?.toISOString().split('.')[0].replaceAll(':', '_');
+
       image && (await this.attach(image, 'image/png'));
       await this.context?.tracing.stop({
-        path: `${tracesDir}/${this.testName}-${
-          this.startTime?.toISOString().split('.')[0]
-        }trace.zip`,
+        path: `${tracesDir}/${this.testName}-${timePart}trace.zip`,
       });
     }
   }


### PR DESCRIPTION
Hi Tallyb,

We had trouble getting this template to work on Windows. Seems like it's an issue with what characters are allowed in Windows paths.

Windows paths aren't allowed to contain certain characters like :. Using that character in a path causes a 'ENOENT' error to be raised. Replacing these characters with underscores fixes the issue.

![image](https://user-images.githubusercontent.com/115535277/222371618-491ee12b-b630-4638-88b9-e5c4a3b69f9b.png)

This is probably the same issue these people ran into:

- https://github.com/Tallyb/cucumber-playwright/issues/554 (I see my colleague commented on that issue as well 😅)
- https://github.com/Tallyb/cucumber-playwright/issues/381