### PR TITLE
fix(scripts): update npm scripts for Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "cucumber": "tsx node_modules/.bin/cucumber-js",
+    "cucumber": "tsx node_modules/@cucumber/cucumber/bin/cucumber.js",
     "api": "DEBUG=pw:api npm run cucumber",
     "build": "rimraf build && npm run format && npm run lint && tsc && npm run cucumber-check",
     "cucumber-check": "npm run cucumber features/**/*.feature --dry-run --require env/set-environment-variables.ts --require world/custom-world.ts --require step-definitions/**/*.ts --require hooks/**/*.ts  --require-module ts-node/register --format-options \"{\\\"snippetInterface\\\": \\\"async-await\\\"}\" --format summary --format progress --format progress-bar  --publish-quiet",
@@ -16,7 +16,7 @@
     "only": "npm run cucumber -- --tags @only",
     "report": "open reports/report.html",
     "snippets": "npm run cucumber  features/**/*.feature --dry-run --format snippets",
-    "steps-usage": "tsx $(bin)/cucumber-js features/**/*.feature --dry-run",
+    "steps-usage": "tsx node_modules/@cucumber/cucumber/bin/cucumber.js features/**/*.feature --dry-run",
     "all": "npm run cucumber features/**/*.feature",
     "test": "npm run cucumber ",
     "test:parallel": "npm run cucumber  --parallel=2",


### PR DESCRIPTION
In a Windows environment, the link to node_modules/.bin/cucumber-js fails to run. To address this, we need to manually choose between cucumber-js.cmd and cucumber-js.ps1. As a solution, I skipped the CLI bootstrap and linked directly to the actual JavaScript file instead.