### PR TITLE
Fix link to cucumber.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The last reporter/formatter found on the cucumber-js command-line wins:
 --format summary --format @cucumber/pretty-formatter --format cucumber-console-formatter
 ```
 
-In [cucumber.mjs](cucumber.mjs) file, modify the options.
+In [cucumber.js](cucumber.js) file, modify the options.
 
 
 To use Allure reporting, you can run with env param: `USE_ALLURE=1`, and then use the `npm run allure` to show the report.


### PR DESCRIPTION
Hi, thanks for this example repo!

The previous file `cucumber.mjs` was renamed to `cucumber.js` in this commit:

- https://github.com/Tallyb/cucumber-playwright/commit/e4ca7fe41015ae0c1f7e86dab49e3a863969f66c